### PR TITLE
CI: buildah to build images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,27 +65,28 @@ build-publish-docker-release:
   <<:                              *build-only
   <<:                              *kubernetes-build
   stage:                           dockerize
-  image:                           docker:stable
-  services:
-    - docker:dind
+  image:                           quay.io/buildah/stable
   # collect VERSION artifact here to pass it on to kubernetes
   variables:
-    DOCKER_HOST:                   tcp://localhost:2375
-    DOCKER_DRIVER:                 overlay2
     # GIT_STRATEGY:                none
     # DOCKERFILE:                  scripts/docker/Dockerfile
     CONTAINER_IMAGE:               parity/substrate-analytics
   before_script:
-    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity"
-        || ( echo "no docker credentials provided"; exit 1 )
-    - docker login -u "$Docker_Hub_User_Parity" -p "$Docker_Hub_Pass_Parity"
-    - docker info
+    - test "$Docker_Hub_User_Parity" -a "$Docker_Hub_Pass_Parity" ||
+        ( echo "no docker credentials provided"; exit 1 )
+    - echo "$Docker_Hub_Pass_Parity" |
+        buildah login --username "$Docker_Hub_User_Parity" --password-stdin docker.io
+    - buildah info
   script:
-    - docker build --tag $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA --tag $CONTAINER_IMAGE:latest .
-    - docker push $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA
-    - docker push $CONTAINER_IMAGE:latest
+    - buildah bud
+        --squash
+        --format=docker
+        --tag "$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
+        --tag "$CONTAINER_IMAGE:latest" .
+    - buildah push --format=v2s2 $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA
+                                 $CONTAINER_IMAGE:latest
   after_script:
-    - docker logout
+    - buildah logout docker.io
   except:
     variables:
       - $DEPLOY_TAG


### PR DESCRIPTION
Fixes the issue with containerization.

Images manifests are changing with the transition to buildah.

For the reference paritytech/scripts#246