### PR TITLE
CI: remove squash and fix buildah push

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,12 +79,11 @@ build-publish-docker-release:
     - buildah info
   script:
     - buildah bud
-        --squash
         --format=docker
         --tag "$CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA"
         --tag "$CONTAINER_IMAGE:latest" .
     - buildah push --format=v2s2 $CONTAINER_IMAGE:$CI_COMMIT_SHORT_SHA
-                                 $CONTAINER_IMAGE:latest
+    - buildah push --format=v2s2 $CONTAINER_IMAGE:latest
   after_script:
     - buildah logout docker.io
   except:


### PR DESCRIPTION
- fixes buildah bush, apparently it couldn't push several tags within one command
- removes --squash, is wins in the final image size, but makes it one layer, hence unable to reuse the base image, looses in download time.
